### PR TITLE
fix: handle users.info response

### DIFF
--- a/src/utils/slackClient.ts
+++ b/src/utils/slackClient.ts
@@ -251,7 +251,7 @@ class EnhancedSlackClient {
     }
 
     const userInfo = await this.getUserInfo(user);
-    if (!userInfo.success || !userInfo.user) {
+    if (!userInfo.ok || !userInfo.user) {
       throw new Error(`Could not resolve user: ${user}`);
     }
 

--- a/tests/unit/utils/slackClient.test.ts
+++ b/tests/unit/utils/slackClient.test.ts
@@ -39,4 +39,14 @@ describe('slackClient', () => {
     const result = await slackClient.resolveChannelId('general');
     expect(result).toBe('C1234567890');
   });
+
+  it('should resolve user ID', async () => {
+    jest.spyOn(slackClient, 'getUserInfo').mockResolvedValue({
+      ok: true,
+      user: { id: 'U1234567890' }
+    } as any);
+
+    const result = await slackClient.resolveUserId('testuser');
+    expect(result).toBe('U1234567890');
+  });
 });


### PR DESCRIPTION
## Summary
- fix resolveUserId to check `ok` flag from `users.info`
- add unit test covering `resolveUserId` with successful user lookup

## Testing
- `npm test tests/unit/utils/slackClient.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68b1dc2b24d4832dba23bee765624a2d