### PR TITLE
Add retry support to Slack auth test tool

### DIFF
--- a/tests/unit/tools/slackAuthTest.test.ts
+++ b/tests/unit/tools/slackAuthTest.test.ts
@@ -1,16 +1,20 @@
 import { slackAuthTestTool } from '../../../src/tools/slackAuthTest';
 import { slackClient } from '../../../src/utils/slackClient';
+import { ErrorRecovery } from '../../../src/utils/errorRecovery';
 
 jest.mock('../../../src/utils/slackClient');
+jest.mock('../../../src/utils/errorRecovery');
 const mockSlackClient = slackClient as jest.Mocked<typeof slackClient>;
+const mockRecovery = ErrorRecovery as jest.Mocked<typeof ErrorRecovery>;
 
 describe('slackAuthTestTool', () => {
   let mockClient: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockClient = {};
+    mockClient = { auth: { test: jest.fn() } } as any;
     mockSlackClient.getClient.mockReturnValue(mockClient);
+    mockRecovery.executeWithRetry.mockImplementation(fn => fn());
   });
 
   it('should have correct tool metadata', () => {
@@ -20,8 +24,29 @@ describe('slackAuthTestTool', () => {
   });
 
   it('should execute successfully', async () => {
+    mockClient.auth.test.mockResolvedValue({ ok: true });
     const result = await slackAuthTestTool.execute({});
     expect(result).toBeDefined();
     expect(typeof result.success).toBe('boolean');
+    expect(mockRecovery.executeWithRetry).toHaveBeenCalled();
+  });
+
+  it('retries on transient failure', async () => {
+    mockClient.auth.test
+      .mockRejectedValueOnce({ code: 'rate_limited' })
+      .mockResolvedValue({ ok: true });
+
+    mockRecovery.executeWithRetry.mockImplementation(async fn => {
+      try {
+        return await fn();
+      } catch {
+        return await fn();
+      }
+    });
+
+    const result = await slackAuthTestTool.execute({});
+    expect(result.success).toBe(true);
+    expect(mockClient.auth.test).toHaveBeenCalledTimes(2);
+    expect(mockRecovery.executeWithRetry).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- use `ErrorRecovery.executeWithRetry` in `slack_auth_test` tool with configurable options
- mock `ErrorRecovery` in tests and validate retry on transient errors

## Testing
- `npm test` *(fails: Real Slack Environment Integration Tests, aiAnalytics utilities)*

------
https://chatgpt.com/codex/tasks/task_b_68b1dce67de4832d8bbe494542dd3dbc