### PR TITLE
feat: paginate user lookup

### DIFF
--- a/tests/unit/utils/slackClient.test.ts
+++ b/tests/unit/utils/slackClient.test.ts
@@ -16,13 +16,14 @@ jest.mock('@slack/web-api', () => ({
         channel: { id: 'C1234567890', name: 'general' }
       })
     },
-    users: { list: jest.fn() },
+    users: { list: jest.fn(), info: jest.fn() },
   })),
 }));
 
 describe('slackClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    slackClient.clearCache();
     // Mock the getChannelInfo method
     jest.spyOn(slackClient, 'getChannelInfo').mockResolvedValue({
       success: true,
@@ -38,5 +39,27 @@ describe('slackClient', () => {
   it('should resolve channel ID', async () => {
     const result = await slackClient.resolveChannelId('general');
     expect(result).toBe('C1234567890');
+  });
+
+  it('should resolve user ID across paginated responses', async () => {
+    const client: any = slackClient.getClient();
+    (client.users.list as jest.Mock)
+      .mockResolvedValueOnce({
+        members: [{ id: 'U1', name: 'someone' }],
+        response_metadata: { next_cursor: 'abc' },
+      })
+      .mockResolvedValueOnce({
+        members: [{ id: 'U123', name: 'john' }],
+        response_metadata: { next_cursor: '' },
+      });
+
+    (client.users.info as jest.Mock).mockResolvedValue({
+      ok: true,
+      user: { id: 'U123', name: 'john' },
+    });
+
+    const result = await slackClient.resolveUserId('john');
+    expect(result).toBe('U123');
+    expect((client.users.list as jest.Mock).mock.calls.length).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- iterate through `users.list` pages when resolving usernames
- guard against runaway pagination with a 50 page safety limit
- test paginated lookup to ensure user ID resolution

## Testing
- `npm test tests/unit/utils/slackClient.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_68b1dd0b1a5c832dad036839401aa514